### PR TITLE
Remove instance scope

### DIFF
--- a/tests/test_instance_creation.py
+++ b/tests/test_instance_creation.py
@@ -96,13 +96,6 @@ def test_resolves_instances_with_prototype_scope():
     expect(mw1).not_to(equal(mw2))
 
 
-def test_registering_instance_scope_without_an_instance_is_exception():
-    container = Container()
-
-    with pytest.raises(InvalidRegistrationException):
-        container.register(MessageWriter, StdoutMessageWriter, scope=Scope.instance)
-
-
 def test_registering_an_instance_as_concrete_is_exception():
     """
     Concrete registrations need to be a constructable type


### PR DESCRIPTION
Hey!

This still passes your tests, but I think is slightly simpler? This is what I was driving at before: the thing I don't like is that the scope is _always_ singleton when you pass an instance, and having an extra style there makes less sense to me than just _ignoring_ scope for instance registrations.

In this PR, we treat instance registrations as singleton for the purposes of resolution, and drop the `instance` scope value.